### PR TITLE
Corrected tests_timeout_raises to ensure timeouts are triggered properly

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -18,7 +18,7 @@ class DecoratorsTestCase(unittest.TestCase):
     def test_timeout_raises(self):
         @timeout(1)
         def very_slow_function():
-            time.sleep(5)
+            time.sleep(3)
         before_exec = time.time()
         with self.assertRaisesRegexp(TimeoutError, 'Function call timed out'):
             very_slow_function()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -18,9 +18,12 @@ class DecoratorsTestCase(unittest.TestCase):
     def test_timeout_raises(self):
         @timeout(1)
         def very_slow_function():
-            time.sleep(2)
+            time.sleep(5)
+        before_exec = time.time()
         with self.assertRaisesRegexp(TimeoutError, 'Function call timed out'):
             very_slow_function()
+        after_exec = time.time()
+        self.assertTrue(after_exec - before_exec < 2, 'Function did not timeout properly.')
 
     def test_debug_default_logger(self):
         @debug()


### PR DESCRIPTION
Prior version of test merely checked to see if the `TimeoutError` was raised, not when it was raised. As a result students could write passing code that would only raise the error *after* the decorated function is finished executing, instead of terminating execution when the timeout occurs. An example of this I noticed multiple times in the recent session was that they would store the time before execution and after execution, and then compare. If the difference was greater than the timeout length then they raised the `TimeoutError`. That would pass under the old test. New test also checks execution time and if that's longer than the timeout it raises an error.