### PR TITLE
Unit test bugfixes

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -18,9 +18,12 @@ class DecoratorsTestCase(unittest.TestCase):
     def test_timeout_raises(self):
         @timeout(1)
         def very_slow_function():
-            time.sleep(2)
+            time.sleep(3)
+        before = time.time()
         with self.assertRaisesRegexp(TimeoutError, 'Function call timed out'):
             very_slow_function()
+        after = time.time()
+        self.assertTrue(after - before < 3, "Function allowed to execute past timeout.")
 
     def test_debug_default_logger(self):
         @debug()
@@ -100,3 +103,15 @@ class DecoratorsTestCase(unittest.TestCase):
         self.assertEqual(add.cache, {(1, 2): 3, (2, 3): 5})
         self.assertEqual(add(3, 4), 7)
         self.assertEqual(add.cache, {(1, 2): 3, (2, 3): 5, (3, 4): 7})
+
+    def test_memoized_using_cached_values(self):
+    	@memoized
+    	def slow_add(a, b):
+    		time.sleep(3)
+    		return a + b
+
+    	self.assertEqual(slow_add(1, 2), 3)
+    	before = time.time()
+    	self.assertEqual(slow_add(1, 2), 3)
+    	after = time.time()
+    	self.assertTrue(after - before < 3, "Not using cached value.")

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import time
 import unittest
+from unittest.mock import patch
 from testfixtures import LogCapture
 
 from decorators_library.decorators import *
@@ -103,15 +104,5 @@ class DecoratorsTestCase(unittest.TestCase):
         self.assertEqual(add.cache, {(1, 2): 3, (2, 3): 5})
         self.assertEqual(add(3, 4), 7)
         self.assertEqual(add.cache, {(1, 2): 3, (2, 3): 5, (3, 4): 7})
-
-    def test_memoized_using_cached_values(self):
-    	@memoized
-    	def slow_add(a, b):
-    		time.sleep(3)
-    		return a + b
-
-    	self.assertEqual(slow_add(1, 2), 3)
-    	before = time.time()
-    	self.assertEqual(slow_add(1, 2), 3)
-    	after = time.time()
-    	self.assertTrue(after - before < 3, "Not using cached value.")
+        with patch.dict(add.cache, {(1, 2): 6}):
+            self.assertEqual(add(1, 2), 6, "Not using cached value")


### PR DESCRIPTION
- Changed timeout unit test so that it requires the exception to raise before the wrapped function's execution is finished. (Before students could just compare the time before execution and after, and if it was longer than the timeout raise the exception)
- Changed memoize unit test so that it requires that if the parameters are in the cache that they return the value from the cache. (Before the tests would pass if they merely ran the function and stored the result in the cache, without ever checking if it was already there)